### PR TITLE
Use absolute path to binary.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 sudo: false
 
 go:
-  - 1.5
+  - 1.8
   - tip
 
 matrix:

--- a/pomodoro.go
+++ b/pomodoro.go
@@ -119,7 +119,11 @@ func parseCommand(state State, command string) (newState State, output Output) {
 }
 
 func startBeeper() (err error) {
-	command := exec.Command("pomodoro", "beep")
+	ex, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	command := exec.Command(ex, "beep")
 	err = command.Start()
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
Allows for using `tmux-pomodoro` installed outside of `$PATH`